### PR TITLE
feat: add sending the transcript

### DIFF
--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -35,7 +35,9 @@
     "courseTranscript": "Course Transcript",
     "courseDetails": "{title} ({code}): {grade}",
     "fetching": "Fetching...",
-    "notFound": "Student not found"
+    "notFound": "Student not found",
+    "noMetaData": "This connection doesn't have metadata! Enter the student ID to send the transcript.",
+    "noTranscript": "There is no transcript with this student ID!"
   },
   "about": {
     "about": "About",


### PR DESCRIPTION
# Pull Request
## Description

In this PR, I worked on the transcript feature. I added functionality that allows users to select a connection and send a transcript to a student. If the selected connection has metadata, the process is straightforward: after selecting the connection and pressing submit, the transcript is sent.

If the selected connection doesn't have metadata, a Student ID field appears. The user can then enter the Student ID, and if a transcript exists for that Student ID, it will be ready to send upon pressing submit.

Additionally, I added validations to handle errors and ensure a smooth user experience.


## JIRA Ticket(s)

- [KAN-29](https://digicred.atlassian.net/browse/KAN-29)
- [KAN-30](https://digicred.atlassian.net/browse/KAN-30)
- [KAN-31](https://digicred.atlassian.net/browse/KAN-31)

## Type of Change

Please check the corresponding type:
- [ ] Bug fix
- [ ] Chore
- [ ] Documentation
- [x] Feature
- [ ] Hotfix
- [ ] Infrastructure
- [ ] Refactor
- [ ] Test
- [ ] Version bump
- [ ] Other (please add a comment below explaining the type of change)

## Screenshots & Evidence

Send transcript with metadata:

https://github.com/DigiCred-Holdings/traction/assets/32930151/1fdc85a2-be37-47c4-ac37-ceb434fd92fa


Send transcript without metadata:

https://github.com/DigiCred-Holdings/traction/assets/32930151/81c03ce0-d3ad-4489-aaed-4a9b4a07d4d9


