### PR TITLE
feat: Show metadata in the 'Label' column on the Connections page.

### DIFF
--- a/services/tenant-ui/frontend/src/components/connections/Connections.vue
+++ b/services/tenant-ui/frontend/src/components/connections/Connections.vue
@@ -78,6 +78,9 @@
         :header="$t('connect.table.theirLabel')"
         :show-filter-match-modes="false"
       >
+        <template #body="{ data }">
+          {{ getMetadata(data.connection_id) }}</template
+        >
         <template #filter="{ filterModel, filterCallback }">
           <InputText
             v-model="filterModel.value"
@@ -171,6 +174,7 @@ import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';
 import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
+import useGetItem from '@/composables/useGetItem';
 
 const confirm = useConfirm();
 const toast = useToast();
@@ -227,6 +231,29 @@ const deleteDisabled = (connectionAlias: string) => {
   );
 };
 
+// Get Metadata
+const metadataCache = ref<any>({});
+const fetchMetadata = async (connection_id: any) => {
+  if (!metadataCache.value[connection_id]) {
+    const { item, fetchItem } = useGetItem(
+      API_PATH.CONNECTIONS_METADATA(connection_id)
+    );
+    await fetchItem();
+    if (item.value?.results.student_id) {
+      metadataCache.value[connection_id] =
+        `${item.value.results.first_name} ${item.value.results.last_name} - ${item.value.results.student_id}`;
+    } else {
+      metadataCache.value[connection_id] = ' ';
+    }
+  }
+  return metadataCache.value[connection_id];
+};
+const getMetadata = (connection_id: string) => {
+  if (!metadataCache.value[connection_id]) {
+    fetchMetadata(connection_id);
+  }
+  return metadataCache.value[connection_id] || 'Loading...';
+};
 // The formatted table row
 const formattedConnections: Ref<any[]> = computed(() =>
   filteredConnections.value.map((conn) => ({

--- a/services/tenant-ui/frontend/test/components/connections/Connections.test.ts
+++ b/services/tenant-ui/frontend/test/components/connections/Connections.test.ts
@@ -1,5 +1,5 @@
 import { createTestingPinia } from '@pinia/testing';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import PrimeVue from 'primevue/config';
 import ConfirmationService from 'primevue/confirmationservice';
 import { describe, expect, test, vi } from 'vitest';
@@ -36,6 +36,9 @@ describe('Connections', () => {
   test('formattedConnections maps connections and they render correctly', async () => {
     const wrapper = mountConnections();
     const expectedTexts = ['', 'test.alias', 'BC Wallet', 'active'];
+
+    // Wait for all promises to resolve
+    await flushPromises();
 
     // td is an expected text or valid date
     wrapper.findAll('tbody td').forEach((td) => {


### PR DESCRIPTION
# Pull Request
## Description

This Pull Request enhances the Connections page by displaying student metadata (First Name, Last Name, and StudentID) in the their_label column. The metadata is automatically added to the connection when a Student ID is issued.


## JIRA Ticket(s)

- [KAN-94](https://digicred.atlassian.net/browse/KAN-94)

## Type of Change

Please check the corresponding type:
- [ ] Bug fix
- [ ] Chore
- [ ] Documentation
- [x] Feature
- [ ] Hotfix
- [ ] Infrastructure
- [ ] Refactor
- [ ] Test
- [ ] Version bump
- [ ] Other (please add a comment below explaining the type of change)

## Screenshots & Evidence

https://github.com/DigiCred-Holdings/traction/assets/32930151/408e64f9-6338-47f5-8d79-929ac5f1ada6






