### PR TITLE
feat: Adding svg

### DIFF
--- a/services/tenant-ui/frontend/src/views/transcript/Transcript.vue
+++ b/services/tenant-ui/frontend/src/views/transcript/Transcript.vue
@@ -66,7 +66,9 @@
             v-if="transcriptContent && !transcriptLoading"
             class="pt-4 transcriptContent"
           >
-            <Card>
+            <!-- TODO: 'v-html' directive can lead to XSS attack. -->
+            <div class="taa-html mb-4" v-html="svg?.data" />
+            <!-- <Card>
               <template #content>
                 <div>
                   <strong>{{ `${$t('transcript.studentID')}: ` }}</strong>
@@ -96,7 +98,7 @@
                   />
                 </div>
               </template>
-            </Card>
+            </Card> -->
           </div>
 
           <Button
@@ -223,6 +225,7 @@ const getTranscript = async (student_id: string) => {
 const payload = ref();
 const sisApi = useSisApi();
 const credentialDefinitionId = ref();
+const svg = ref();
 // Create payload
 const createPayload = async () => {
   const GPA =
@@ -330,6 +333,7 @@ onMounted(async () => {
   credentialDefinitionId.value = (
     await sisApi.getHttp(`metadata/transcript-credential-definition-id`)
   ).data?.transcriptCredentialDefinitionId;
+  svg.value = await sisApi.getHttp(`svg/generate`);
 });
 </script>
 


### PR DESCRIPTION
# Pull Request
## Description

This PR introduces a new feature that displays an SVG on the transcript page before the transcript is sent. 

## JIRA Ticket(s)
N/A

## Type of Change

Please check the corresponding type:
- [ ] Bug fix
- [ ] Chore
- [ ] Documentation
- [x] Feature
- [ ] Hotfix
- [ ] Infrastructure
- [ ] Refactor
- [ ] Test
- [ ] Version bump
- [ ] Other (please add a comment below explaining the type of change)

## Screenshots & Evidence

https://github.com/DigiCred-Holdings/cape-fear-aca-py-controller/assets/32930151/b55e4ac6-e7be-4b26-96e3-2201e80ee38f

