### PR TITLE
feat: Added a content-security-policy to our headers

### DIFF
--- a/services/tenant-ui/package-lock.json
+++ b/services/tenant-ui/package-lock.json
@@ -18,6 +18,7 @@
         "eta": "^3.5.0",
         "express": "^4.21.1",
         "express-validator": "^7.2.0",
+        "helmet": "^8.1.0",
         "jose": "^5.9.6",
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^3.0.3",
@@ -3977,6 +3978,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/services/tenant-ui/package.json
+++ b/services/tenant-ui/package.json
@@ -25,6 +25,7 @@
     "eta": "^3.5.0",
     "express": "^4.21.1",
     "express-validator": "^7.2.0",
+    "helmet": "^8.1.0",
     "jose": "^5.9.6",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",

--- a/services/tenant-ui/src/index.ts
+++ b/services/tenant-ui/src/index.ts
@@ -1,6 +1,7 @@
 import config from "config";
 import cors from "cors";
 import express from "express";
+import helmet from "helmet";
 import path from "path";
 
 import { router } from "./routes/router";
@@ -15,6 +16,23 @@ const STATIC_FILES_PATH: string = config.get("server.staticFiles");
 import history from "connect-history-api-fallback";
 
 const app = express();
+
+// Apply Helmet's default security headers
+app.use(helmet());
+
+// Apply a specific Content Security Policy
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      // It's likely need to adjust this later to allow resources from CDNs or other trusted domains that our application uses.
+      defaultSrc: ["'self'"], // Which means that the only sources of content are the same origin
+      // Add other directives here as needed, for example:
+      // scriptSrc: ["'self'", "trusted-cdn.com"],
+      // styleSrc: ["'self'", "'unsafe-inline'"], // Allow inline styles if necessary
+      // imgSrc: ["'self'", "data:"] // Allow data URIs for images
+    },
+  })
+);
 
 app.use(history());
 app.use(cors());


### PR DESCRIPTION
I added Helmet and configure a basic Content Security Policy. We start with a restrictive policy, default-src 'self', which means that by default, resources (scripts, styles, images, etc.) can only be loaded from the same origin as our application. We'll likely need to adjust this later to allow resources from CDNs or other trusted domains our application uses.


1) Imported helmet at the top of services/tenant-ui/src/index.ts.
2) Added app.use(helmet()) to apply all of Helmet's default protections.
3) Added app.use(helmet.contentSecurityPolicy({...})) with a basic default-src 'self' directive. It's generally recommended to add helmet.contentSecurityPolicy separately if we want to configure it, as helmet() itself sets a default CSP that might be too restrictive or not what we specifically need for a penetration test.