### PR TITLE
feat: added truncate function in the enrollment page

### DIFF
--- a/services/tenant-ui/frontend/src/components/enrollments/TranscriptPrintableView.vue
+++ b/services/tenant-ui/frontend/src/components/enrollments/TranscriptPrintableView.vue
@@ -61,7 +61,9 @@
             :key="'transfer-' + index"
           >
             <td>{{ course.course_code }}</td>
-            <td>{{ course.title }}</td>
+            <td style="max-width: 150px">
+              {{ truncateText(course.title, 20) }}
+            </td>
             <td>{{ (course.credits_earned || 0).toFixed(2) }}</td>
             <td>{{ course.transfer_school_name }}</td>
           </tr>
@@ -112,7 +114,9 @@
               :key="'course-' + termIndex + '-' + courseIndex"
             >
               <td>{{ course.courseCode }}</td>
-              <td>{{ course.courseTitle }}</td>
+              <td style="max-width: 150px">
+                {{ truncateText(course.courseTitle, 20) }}
+              </td>
               <td>{{ course.grade }}</td>
               <td>{{ course.repeat_indicator || '' }}</td>
               <td>{{ (course.hours_attempted || 0).toFixed(2) }}</td>
@@ -458,6 +462,13 @@ const totalTransferCredits = computed(() => {
     0
   );
 });
+
+const truncateText = (text, maxLength) => {
+  if (typeof text === 'string' && text.length > maxLength) {
+    return text.substring(0, maxLength - 3) + '...';
+  }
+  return text;
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Description
Added a `truncateText` helper function to handle long text content in transcript table cells, particularly for course titles and comments. This prevents text overflow and maintains clean table formatting in the generated transcript documents.

### Changes
- Added `truncateText` utility function that truncates strings longer than the specified length and adds an ellipsis
- Applied truncation to course titles in both transferred courses and term course tables
- Set default max length to 20 characters to maintain consistent column widths

### Screenshots


https://github.com/user-attachments/assets/dc8da3e9-b28f-425e-9953-7a97ea62eb74


