### PR TITLE
Increase limit from the default of 100 to 1500

### DIFF
--- a/services/tenant-ui/frontend/src/store/connectionStore.ts
+++ b/services/tenant-ui/frontend/src/store/connectionStore.ts
@@ -56,7 +56,7 @@ export const useConnectionStore = defineStore('connection', () => {
 
   async function listConnections() {
     selectedConnection.value = null;
-    return fetchList(API_PATH.CONNECTIONS, connections, error, loading, {});
+    return fetchList(API_PATH.CONNECTIONS, connections, error, loading, {limit: 1500});
   }
 
   async function createInvitation(alias: string, multiUse: boolean) {


### PR DESCRIPTION
The UI is only requesting a default of 100 connections and nothing more. Further more, this list appears to be shared with invitations. This change should bump that number up from 100 connections to 1,500