### PR TITLE
Feature: OpenID Connect (With Google) Support

### DIFF
--- a/services/tenant-ui/config/custom-environment-variables.json
+++ b/services/tenant-ui/config/custom-environment-variables.json
@@ -54,9 +54,13 @@
     "content-security-policy": "CONTENT_SECURITY_POLICY",
     "corsAllowedOrigins": "CORS_ALLOWED_ORIGINS",
     "oidc": {
+      "clientId": "SERVER_OIDC_CLIENT_ID",
+      "clientSecret": "SERVER_OIDC_CLIENT_SECRET",
       "jwksUri": "SERVER_OIDC_JWKS",
+      "authority": "SERVER_OIDC_AUTHORITY",
       "realm": "SERVER_OIDC_REALM",
-      "roleName": "SERVER_OIDC_ROLE"
+      "roleName": "SERVER_OIDC_ROLE",
+      "allowedUsers": "SERVER_OIDC_ALLOWED_USERS"
     },
     "innkeeper": {
       "user": "SERVER_INNKEEPER_USER",

--- a/services/tenant-ui/config/default.json
+++ b/services/tenant-ui/config/default.json
@@ -60,9 +60,13 @@
     "content-security-policy": "CONTENT_SECURITY_POLICY",
     "corsAllowedOrigins": "CORS_ALLOWED_ORIGINS",
     "oidc": {
+      "clientId": "",
+      "clientSecret": "",
       "jwksUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs",
+      "authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz",
       "realm": "digitaltrust-citz",
-      "roleName": "innkeeper"
+      "roleName": "innkeeper",
+      "allowedUsers": ""
     },
     "innkeeper": {
       "user": "innkeeper",

--- a/services/tenant-ui/frontend/src/components/oidc/LoginOIDC.vue
+++ b/services/tenant-ui/frontend/src/components/oidc/LoginOIDC.vue
@@ -1,5 +1,10 @@
 <template>
-  <Button class="w-full mt-5" :label="config.frontend.oidc.label" :loading="loading" @click="login" />
+  <Button
+    class="w-full mt-5"
+    :label="config.frontend.oidc.label"
+    :loading="loading"
+    @click="login"
+  />
   <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
   <div v-if="error">{{ $t('admin.error') }}: {{ error }}</div>
 </template>

--- a/services/tenant-ui/frontend/src/components/oidc/LoginOIDC.vue
+++ b/services/tenant-ui/frontend/src/components/oidc/LoginOIDC.vue
@@ -7,9 +7,12 @@
 <script setup lang="ts">
 import Button from 'primevue/button';
 import { useOidcStore } from '@/store';
+import { useConfigStore } from '../../store';
 
 import { storeToRefs } from 'pinia';
 import { useToast } from 'vue-toastification';
+
+const { config } = storeToRefs(useConfigStore());
 
 const toast = useToast();
 const oidcStore = useOidcStore();

--- a/services/tenant-ui/frontend/src/components/oidc/LoginOIDC.vue
+++ b/services/tenant-ui/frontend/src/components/oidc/LoginOIDC.vue
@@ -1,5 +1,5 @@
 <template>
-  <Button class="w-full mt-5" label="IDIR" :loading="loading" @click="login" />
+  <Button class="w-full mt-5" :label="config.frontend.oidc.label" :loading="loading" @click="login" />
   <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
   <div v-if="error">{{ $t('admin.error') }}: {{ error }}</div>
 </template>

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -16,6 +16,7 @@ export const API_PATH = {
 
   // TODO: Align these urls
   OIDC_INNKEEPER_LOGIN: '/api/innkeeperLogin',
+  OIDC_OIDC_LOGIN: '/api/oidcLogin',
   OIDC_INNKEEPER_RESERVATION: '/innkeeperReservation',
 
   // Acapy and Plugins

--- a/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
+++ b/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
@@ -25,12 +25,9 @@ class UserManager_TactionOverride extends UserManager {
   public async checkSigninResponseState(url: string = window.location.href, removeState: boolean = true) {
     const oid_response = await this._client.readSigninResponseState(url, removeState);
     if (oid_response) {
-      // await this._processSigninResponse(oid_response);
       const loginCfg = {
-        // headers: { Authorization: `Bearer ${oidcUser?.access_token}` },
       };
       const response: any = await axios.post(
-        // API_PATH.OIDC_INNKEEPER_LOGIN,
         API_PATH.OIDC_OIDC_LOGIN,
         oid_response,
         loginCfg,
@@ -70,29 +67,12 @@ export const useOidcStore = defineStore('oidcStore', () => {
   .catch((err:any) => {
     console.error(err);
   });
-  // userManager
-  //   .signinRedirectCallback()
-  //   .then(() => {
-  //     loading.value = true;
-  //   })
-  //   .catch((err) => {
-  //     console.error(err);
-  //   });
 
   userManager.onSuccessfulSignin(async (token_response: any) => {
     try {
       // Get the logged in user from the OIDC library
       const oidcUser = await userManager.getUser();
       user.value = oidcUser;
-
-      // const loginCfg = {
-      //   headers: { Authorization: `Bearer ${oidcUser?.access_token}` },
-      // };
-      // const response: any = await axios.get(
-      //   // API_PATH.OIDC_INNKEEPER_LOGIN,
-      //   API_PATH.OIDC_OIDC_LOGIN,
-      //   loginCfg
-      // );
       token.value = token_response.token;
       if (token.value) localStorage.setItem('token', token.value);
 

--- a/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
+++ b/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
@@ -6,7 +6,6 @@ import { UserManager } from 'oidc-client-ts';
 import { OidcClient } from 'oidc-client-ts';
 import { configStringToObject } from '@/helpers';
 import { API_PATH } from '@/helpers/constants';
-// import { useTokenStore } from '../tokenStore';
 import { useToast } from 'vue-toastification';
 import { useRouter } from 'vue-router';
 import { useTenantStore, useTokenStore } from '../../store';

--- a/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
+++ b/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
@@ -3,12 +3,43 @@ import { defineStore, storeToRefs } from 'pinia';
 import { ref } from 'vue';
 import { useConfigStore } from '../configStore';
 import { UserManager } from 'oidc-client-ts';
+import { OidcClient } from 'oidc-client-ts';
 import { configStringToObject } from '@/helpers';
 import { API_PATH } from '@/helpers/constants';
 // import { useTokenStore } from '../tokenStore';
 import { useToast } from 'vue-toastification';
 import { useRouter } from 'vue-router';
 import { useTenantStore, useTokenStore } from '../../store';
+
+class UserManager_TactionOverride extends UserManager {
+  private _signinCb: (token: any) => void = (token: any) => {};
+  public constructor(...args: ConstructorParameters<typeof UserManager>) {
+    super(...args);
+  }
+  public get_client(): OidcClient {
+    return this._client;
+  }
+  public onSuccessfulSignin(cb: (token: any) => void) {
+    this._signinCb = cb;
+  }
+  public async checkSigninResponseState(url: string = window.location.href, removeState: boolean = true) {
+    const oid_response = await this._client.readSigninResponseState(url, removeState);
+    if (oid_response) {
+      // await this._processSigninResponse(oid_response);
+      const loginCfg = {
+        // headers: { Authorization: `Bearer ${oidcUser?.access_token}` },
+      };
+      const response: any = await axios.post(
+        // API_PATH.OIDC_INNKEEPER_LOGIN,
+        API_PATH.OIDC_OIDC_LOGIN,
+        oid_response,
+        loginCfg,
+      );
+      console.log("OIDC Login Response:", response.data);
+      this._signinCb(response.data);
+    }
+  }
+}
 
 export const useOidcStore = defineStore('oidcStore', () => {
   // Stores
@@ -30,32 +61,39 @@ export const useOidcStore = defineStore('oidcStore', () => {
     ),
   };
 
-  const userManager: UserManager = new UserManager(settings);
+  const userManager: UserManager_TactionOverride = new UserManager_TactionOverride(settings);
+  userManager.checkSigninResponseState()
+  .then(async (val: any) => {
+    console.log('signed in', val);
+    loading.value = true;
+  })
+  .catch((err:any) => {
+    console.error(err);
+  });
+  // userManager
+  //   .signinRedirectCallback()
+  //   .then(() => {
+  //     loading.value = true;
+  //   })
+  //   .catch((err) => {
+  //     console.error(err);
+  //   });
 
-  userManager
-    .signinRedirectCallback()
-    .then(() => {
-      loading.value = true;
-    })
-    .catch((err) => {
-      console.error(err);
-    });
-
-  userManager.events.addUserLoaded(async () => {
+  userManager.onSuccessfulSignin(async (token_response: any) => {
     try {
       // Get the logged in user from the OIDC library
       const oidcUser = await userManager.getUser();
       user.value = oidcUser;
 
-      const loginCfg = {
-        headers: { Authorization: `Bearer ${oidcUser?.access_token}` },
-      };
-      const response: any = await axios.get(
-        // API_PATH.OIDC_INNKEEPER_LOGIN,
-        API_PATH.OIDC_OIDC_LOGIN,
-        loginCfg
-      );
-      token.value = response.data.token;
+      // const loginCfg = {
+      //   headers: { Authorization: `Bearer ${oidcUser?.access_token}` },
+      // };
+      // const response: any = await axios.get(
+      //   // API_PATH.OIDC_INNKEEPER_LOGIN,
+      //   API_PATH.OIDC_OIDC_LOGIN,
+      //   loginCfg
+      // );
+      token.value = token_response.token;
       if (token.value) localStorage.setItem('token', token.value);
 
       // Strip the oidc return params
@@ -100,7 +138,7 @@ export const useOidcStore = defineStore('oidcStore', () => {
   // Ations
   async function login() {
     loading.value = true;
-    return userManager.signinRedirect();
+    return userManager.signinRedirect({prompt: 'select_account', scope: 'openid profile email'});
   }
 
   return {

--- a/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
+++ b/services/tenant-ui/frontend/src/store/oidc/oidcStore.ts
@@ -22,17 +22,22 @@ class UserManager_TactionOverride extends UserManager {
   public onSuccessfulSignin(cb: (token: any) => void) {
     this._signinCb = cb;
   }
-  public async checkSigninResponseState(url: string = window.location.href, removeState: boolean = true) {
-    const oid_response = await this._client.readSigninResponseState(url, removeState);
+  public async checkSigninResponseState(
+    url: string = window.location.href,
+    removeState: boolean = true
+  ) {
+    const oid_response = await this._client.readSigninResponseState(
+      url,
+      removeState
+    );
     if (oid_response) {
-      const loginCfg = {
-      };
+      const loginCfg = {};
       const response: any = await axios.post(
         API_PATH.OIDC_OIDC_LOGIN,
         oid_response,
-        loginCfg,
+        loginCfg
       );
-      console.log("OIDC Login Response:", response.data);
+      console.log(`OIDC Login Response:`, response.data);
       this._signinCb(response.data);
     }
   }
@@ -58,15 +63,19 @@ export const useOidcStore = defineStore('oidcStore', () => {
     ),
   };
 
-  const userManager: UserManager_TactionOverride = new UserManager_TactionOverride(settings);
-  userManager.checkSigninResponseState()
-  .then(async (val: any) => {
-    console.log('signed in', val);
-    loading.value = true;
-  })
-  .catch((err:any) => {
-    console.error(err);
-  });
+  const userManager: UserManager_TactionOverride =
+    new UserManager_TactionOverride(settings);
+
+  userManager
+    .checkSigninResponseState()
+
+    .then(async (val: any) => {
+      console.log('signed in', val);
+      loading.value = true;
+    })
+    .catch((err: any) => {
+      console.error(err);
+    });
 
   userManager.onSuccessfulSignin(async (token_response: any) => {
     try {
@@ -100,7 +109,6 @@ export const useOidcStore = defineStore('oidcStore', () => {
           toast.error(`Failure getting tenant info: ${err}`);
         }
       }
-
     } catch (err: any) {
       error.value = err;
     } finally {
@@ -118,7 +126,10 @@ export const useOidcStore = defineStore('oidcStore', () => {
   // Ations
   async function login() {
     loading.value = true;
-    return userManager.signinRedirect({prompt: 'select_account', scope: 'openid profile email'});
+    return userManager.signinRedirect({
+      prompt: 'select_account',
+      scope: 'openid profile email',
+    });
   }
 
   return {

--- a/services/tenant-ui/src/components/innkeeper.ts
+++ b/services/tenant-ui/src/components/innkeeper.ts
@@ -8,10 +8,28 @@ const INNKEEPER_KEY = config.get("server.innkeeper.key");
  * @function login
  * Use the configured Inkeeper Admin key to get the token
  * @returns {string} The inkeeper token
+ * https://digicred.z.wolkins.net:3020/proxy/multitenancy/wallet/ab1d492c-3c4e-4c3e-b7d2-ff098f028174/token
+ * https://digicred.z.wolkins.net:3020/proxy/multitenancy/tenant/ab1d492c-3c4e-4c3e-b7d2-ff098f028174/token
  */
 export const login = async () => {
   const loginUrl = `${TRACTION_URL}/multitenancy/tenant/${INNKEEPER_USER}/token`;
   const payload = { wallet_key: INNKEEPER_KEY };
+  console.log("Innkeeper login URL:", loginUrl);
+  console.log("Innkeeper login payload:", payload);
+  const res = await axios({
+    method: "post",
+    url: loginUrl,
+    data: payload,
+  });
+
+  return res.data;
+};
+
+export const oidcLogin = async () => {
+  const loginUrl = `${TRACTION_URL}/multitenancy/wallet/${INNKEEPER_USER}/token`;
+  const payload = { wallet_key: INNKEEPER_KEY };
+  console.log("Innkeeper login URL:", loginUrl);
+  console.log("Innkeeper login payload:", payload);
   const res = await axios({
     method: "post",
     url: loginUrl,

--- a/services/tenant-ui/src/components/innkeeper.ts
+++ b/services/tenant-ui/src/components/innkeeper.ts
@@ -8,14 +8,10 @@ const INNKEEPER_KEY = config.get("server.innkeeper.key");
  * @function login
  * Use the configured Inkeeper Admin key to get the token
  * @returns {string} The inkeeper token
- * https://digicred.z.wolkins.net:3020/proxy/multitenancy/wallet/ab1d492c-3c4e-4c3e-b7d2-ff098f028174/token
- * https://digicred.z.wolkins.net:3020/proxy/multitenancy/tenant/ab1d492c-3c4e-4c3e-b7d2-ff098f028174/token
  */
 export const login = async () => {
   const loginUrl = `${TRACTION_URL}/multitenancy/tenant/${INNKEEPER_USER}/token`;
   const payload = { wallet_key: INNKEEPER_KEY };
-  console.log("Innkeeper login URL:", loginUrl);
-  console.log("Innkeeper login payload:", payload);
   const res = await axios({
     method: "post",
     url: loginUrl,
@@ -28,8 +24,6 @@ export const login = async () => {
 export const oidcLogin = async () => {
   const loginUrl = `${TRACTION_URL}/multitenancy/wallet/${INNKEEPER_USER}/token`;
   const payload = { wallet_key: INNKEEPER_KEY };
-  console.log("Innkeeper login URL:", loginUrl);
-  console.log("Innkeeper login payload:", payload);
   const res = await axios({
     method: "post",
     url: loginUrl,

--- a/services/tenant-ui/src/middleware/oidcMiddleware.ts
+++ b/services/tenant-ui/src/middleware/oidcMiddleware.ts
@@ -1,6 +1,7 @@
 import { createRemoteJWKSet, jwtVerify, JWTPayload } from "jose";
 import config from "config";
 import { Request, Response, NextFunction } from "express";
+import axios from "axios";
 
 // Extend Express Request to include claims
 interface AuthenticatedRequest extends Request {
@@ -30,4 +31,56 @@ const oidcMiddleware = async (
   }
 };
 
+console.log("OIDC Middleware loaded");
+const oidcGoogleMiddleware = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+  // console.log("OIDC Google Middleware invoked");
+  const authHeader = req.headers.authorization;
+  // console.log("OIDC Google Middleware - Auth Header:", authHeader);
+  const { state, response } = req.body;
+  // console.error("OIDC Google Middleware - State:", state);
+  // console.error("OIDC Google Middleware - Response:", response);
+  // console.error("OIDC Google Middleware - Beginning token exchange process");
+  
+  // Fetch .well-known/openid-configuration to get token_endpoint
+  const authority: string = config.get("server.oidc.authority");
+  const configId: string = config.get("server.oidc.clientId");
+  const tenantId: string = config.get("server.innkeeper.user");
+  const configSecret: string = config.get("server.oidc.clientSecret");
+  const oid_config = await axios.get(`${authority}/.well-known/openid-configuration`);
+  const tokenEndpoint = oid_config.data.token_endpoint;
+  
+  // Exchange code
+  const tokenResponse = await axios.post(tokenEndpoint, {
+    grant_type: "authorization_code",
+    code: response.code,
+    code_verifier: state.code_verifier,
+    client_id: configId,
+    client_secret: configSecret,
+    redirect_uri: state.redirect_uri,
+  });
+
+  // console.error("Token Response:", tokenResponse.data);
+  
+  // if (!authHeader || !authHeader.startsWith("Bearer ")) {
+  //   res.status(401).json({ message: "Unauthorized" });
+  //   return;
+  // }
+  // const token = authHeader.split(" ")[1];
+  const token = tokenResponse.data.id_token;
+    const { payload } = await jwtVerify(token, jwks);
+    // console.log(`User "${payload.name} <${payload.email}> ($${payload.sub})" logged in via OpenID Connect as ${tenantId}`);
+    req.claims = payload;
+    next();
+  } catch (error) {
+    console.error("OIDC Middleware Error:", error);
+    res.status(401).json({ message: "Invalid token", error });
+  }
+};
+
 export default oidcMiddleware;
+export { oidcGoogleMiddleware };

--- a/services/tenant-ui/src/middleware/oidcMiddleware.ts
+++ b/services/tenant-ui/src/middleware/oidcMiddleware.ts
@@ -31,49 +31,35 @@ const oidcMiddleware = async (
   }
 };
 
-console.log("OIDC Middleware loaded");
 const oidcGoogleMiddleware = async (
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction
 ) => {
   try {
-  // console.log("OIDC Google Middleware invoked");
-  const authHeader = req.headers.authorization;
-  // console.log("OIDC Google Middleware - Auth Header:", authHeader);
-  const { state, response } = req.body;
-  // console.error("OIDC Google Middleware - State:", state);
-  // console.error("OIDC Google Middleware - Response:", response);
-  // console.error("OIDC Google Middleware - Beginning token exchange process");
-  
-  // Fetch .well-known/openid-configuration to get token_endpoint
-  const authority: string = config.get("server.oidc.authority");
-  const configId: string = config.get("server.oidc.clientId");
-  const tenantId: string = config.get("server.innkeeper.user");
-  const configSecret: string = config.get("server.oidc.clientSecret");
-  const oid_config = await axios.get(`${authority}/.well-known/openid-configuration`);
-  const tokenEndpoint = oid_config.data.token_endpoint;
-  
-  // Exchange code
-  const tokenResponse = await axios.post(tokenEndpoint, {
-    grant_type: "authorization_code",
-    code: response.code,
-    code_verifier: state.code_verifier,
-    client_id: configId,
-    client_secret: configSecret,
-    redirect_uri: state.redirect_uri,
-  });
+    const authHeader = req.headers.authorization;
+    const { state, response } = req.body;
+    
+    // Fetch .well-known/openid-configuration to get token_endpoint
+    const authority: string = config.get("server.oidc.authority");
+    const configId: string = config.get("server.oidc.clientId");
+    const tenantId: string = config.get("server.innkeeper.user");
+    const configSecret: string = config.get("server.oidc.clientSecret");
+    const oid_config = await axios.get(`${authority}/.well-known/openid-configuration`);
+    const tokenEndpoint = oid_config.data.token_endpoint;
+    
+    // Exchange code
+    const tokenResponse = await axios.post(tokenEndpoint, {
+      grant_type: "authorization_code",
+      code: response.code,
+      code_verifier: state.code_verifier,
+      client_id: configId,
+      client_secret: configSecret,
+      redirect_uri: state.redirect_uri,
+    });
 
-  // console.error("Token Response:", tokenResponse.data);
-  
-  // if (!authHeader || !authHeader.startsWith("Bearer ")) {
-  //   res.status(401).json({ message: "Unauthorized" });
-  //   return;
-  // }
-  // const token = authHeader.split(" ")[1];
-  const token = tokenResponse.data.id_token;
+    const token = tokenResponse.data.id_token;
     const { payload } = await jwtVerify(token, jwks);
-    // console.log(`User "${payload.name} <${payload.email}> ($${payload.sub})" logged in via OpenID Connect as ${tenantId}`);
     req.claims = payload;
     next();
   } catch (error) {

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -86,16 +86,11 @@ router.get(
   }
 );
 
-console.log("Router loaded");
 router.post(
   "/oidcLogin",
   oidcGoogleMiddleware,
   async (req: any, res: Response, next: NextFunction) => {
     try {
-      // console.log("OIDC Login endpoint invoked");
-      // await oidcGoogleMiddleware(req, res, async () => {
-      //   console.log("Inside OIDC Google Middleware callback");
-      // });
       const allowedUsers = config.get<string>("server.oidc.allowedUsers").split(',').map(u => u.trim());
       const allowedUsersPopulated = allowedUsers.length !== 0 && allowedUsers.every(u => u.length !== 0);
       const tenantId: string = config.get("server.innkeeper.user");
@@ -120,12 +115,11 @@ router.post(
         res.status(200).send(result);
       } else {
         console.log(`User "${req.claims.name} <${req.claims.email}> ($${req.claims.sub})" attempted to log in but is not an authorized user.`);
-        res.status(403).send({ error: "User does not have required role" });
+        res.status(403).send({ error: "User is not authorized to use the system" });
       }
     } catch (error) {
       console.error(`Error logging in: ${error}`);
-      res.status(200).send({"result": "testing"});
-      // next(error);
+      next(error);
     }
   }
 );

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -10,7 +10,6 @@ import acaPyService from "../services/acapy-service";
 import messageService from "../services/message-service";
 import redisService from "../services/redis-service";
 import tiffService from "../services/tiff-service";
-import { all } from "axios";
 
 export const router = express.Router();
 

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -5,10 +5,12 @@ import * as innkeeperComponent from "../components/innkeeper";
 import { body, validationResult } from "express-validator";
 import { NextFunction } from "express";
 import oidcMiddleware from "../middleware/oidcMiddleware";
+import {oidcGoogleMiddleware} from "../middleware/oidcMiddleware";
 import acaPyService from "../services/acapy-service";
 import messageService from "../services/message-service";
 import redisService from "../services/redis-service";
 import tiffService from "../services/tiff-service";
+import { all } from "axios";
 
 export const router = express.Router();
 
@@ -84,27 +86,46 @@ router.get(
   }
 );
 
-router.get(
+console.log("Router loaded");
+router.post(
   "/oidcLogin",
-  oidcMiddleware,
+  oidcGoogleMiddleware,
   async (req: any, res: Response, next: NextFunction) => {
     try {
-      console.log(req.claims);
+      // console.log("OIDC Login endpoint invoked");
+      // await oidcGoogleMiddleware(req, res, async () => {
+      //   console.log("Inside OIDC Google Middleware callback");
+      // });
+      const allowedUsers = config.get<string>("server.oidc.allowedUsers").split(',').map(u => u.trim());
+      const allowedUsersPopulated = allowedUsers.length !== 0 && allowedUsers.every(u => u.length !== 0);
+      const tenantId: string = config.get("server.innkeeper.user");
       if (
-        req.claims.realm_access &&
-        req.claims.realm_access.roles &&
-        req.claims.realm_access.roles.includes(
-          config.get("server.oidc.roleName")
+        req.claims.email_verified &&
+        req.claims.email &&
+        req.claims.email.length > 0 &&
+        req.claims.sub &&
+        req.claims.sub.length > 0 &&
+        allowedUsersPopulated &&
+        (
+          allowedUsers.includes(req.claims.email) ||
+          allowedUsers.includes(req.claims.sub)
         )
       ) {
+        console.log(`Whitelisted User "${req.claims.name} <${req.claims.email}> ($${req.claims.sub})" logged in via OpenID Connect as Tenant ${tenantId}`);
+        const result = await innkeeperComponent.oidcLogin();
+        res.status(200).send(result);
+      } else if (allowedUsersPopulated === false && req.claims.email_verified) {
+        console.log(`User "${req.claims.name} <${req.claims.email}> ($${req.claims.sub})" logged in via OpenID Connect as Tenant ${tenantId}`);
         const result = await innkeeperComponent.oidcLogin();
         res.status(200).send(result);
       } else {
-        res.status(403).send({ error: "User does not have required role", claims: req.claims });
+        console.log(`User "${req.claims.name} <${req.claims.email}> ($${req.claims.sub})" attempted to log in but is not an authorized user.`);
+        res.status(403).send({ error: "User does not have required role" });
       }
     } catch (error) {
       console.error(`Error logging in: ${error}`);
-      next(error);
+      res.status(200).send({"result": "testing"});
+      // next(error);
     }
   }
 );

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -75,7 +75,32 @@ router.get(
         const result = await innkeeperComponent.login();
         res.status(200).send(result);
       } else {
-        res.status(403).send();
+        res.status(403).send({ error: "User does not have required role", claims: req.claims });
+      }
+    } catch (error) {
+      console.error(`Error logging in: ${error}`);
+      next(error);
+    }
+  }
+);
+
+router.get(
+  "/oidcLogin",
+  oidcMiddleware,
+  async (req: any, res: Response, next: NextFunction) => {
+    try {
+      console.log(req.claims);
+      if (
+        req.claims.realm_access &&
+        req.claims.realm_access.roles &&
+        req.claims.realm_access.roles.includes(
+          config.get("server.oidc.roleName")
+        )
+      ) {
+        const result = await innkeeperComponent.oidcLogin();
+        res.status(200).send(result);
+      } else {
+        res.status(403).send({ error: "User does not have required role", claims: req.claims });
       }
     } catch (error) {
       console.error(`Error logging in: ${error}`);


### PR DESCRIPTION
Via the Tenant UI, allow for OpenID Connect Login to a single tenant through the tenant (not Innkeeper) interface.

To take advantage of this feature, the following environment variables need to be set:
```
      FRONTEND_SHOW_OIDC_RESERVATION_LOGIN: true
      FRONTEND_INNKEEPER_OIDC_ACTIVE: true
      FRONTEND_INNKEEPER_OIDC_AUTHORITY: <Your OIDC Authority Server Base URL>
      FRONTEND_INNKEEPER_OIDC_CLIENT: <Your OIDC Client ID>
      FRONTEND_INNKEEPER_OIDC_LABEL: <OIDC Button Label, such as "DigiCred Login">
      SERVER_INNKEEPER_USER: <Your Tenant Wallet ID>
      SERVER_INNKEEPER_KEY: <Your Tenant Wallet Secret>
      SERVER_OIDC_AUTHORITY: <Same as FRONTEND_INNKEEPER_OIDC_AUTHORITY>
      SERVER_OIDC_JWKS: <The JWKS Key Location for this OIDC Authority
      SERVER_OIDC_CLIENT_ID: <Same as FRONTEND_INNKEEPER_OIDC_CLIENT>
      SERVER_OIDC_CLIENT_SECRET: <Your OIDC Client Secret>
      SERVER_OIDC_ALLOWED_USERS: <Comma Delimited Email or OID Subject List>
```